### PR TITLE
Improve documentation how to obtain BBT.StructureTools

### DIFF
--- a/docs/input/docs/getting-started/obtain.md
+++ b/docs/input/docs/getting-started/obtain.md
@@ -4,6 +4,10 @@ Title: Obtain
 Description: Obtain BBT.StructureTools
 ---
 
-## Nuget
+## NuGet
 
-> `nuget install bbt.structuretools`
+Release and Beta versions of BBT.Structure tools are available from [nuget.org](https://www.nuget.org/packages/BBT.StructureTools)
+
+<a class="btn btn-lg btn-success" href="https://www.nuget.org/packages/BBT.StructureTools" target="_blank">
+    <i class="fa fa-download fa-lg"></i> Get from nuget.org
+</a>


### PR DESCRIPTION
Curently it only documents how to get package using `nuget.exe` client. There are other (and more up to date) ways to install NuGet packages like through package manager or `dotnet`. These are all documented on the nuget.org site of the package. Instead of documenting them here again we should just redirect the user to the nuget.org page of the package.