### PR TITLE
Use correct heading levels for TOC generation

### DIFF
--- a/docs/input/docs/comparing-objects/fundamentals.md
+++ b/docs/input/docs/comparing-objects/fundamentals.md
@@ -4,7 +4,7 @@ Title: Fundamentals
 Description: Introduction to the compare capabilities
 ---
 
-## Distinction towards .NET Framework interfaces
+# Distinction towards .NET Framework interfaces
 
 The .NET Framework comes with multiple interfaces which allow for comparison of objects:
 

--- a/docs/input/docs/converting-objects/fundamentals.md
+++ b/docs/input/docs/converting-objects/fundamentals.md
@@ -4,7 +4,7 @@ Title: Fundamentals
 Description: Introduction to the convert capabilities
 ---
 
-## Distinction towards .NET Framework interfaces
+# Distinction towards .NET Framework interfaces
 
 The .NET Framework, as of version 4.8, doesn't offer any conversion capabilities other than
 converting reference and value types into their CLR type of an equivalent value using [System.IConvertible].

--- a/docs/input/docs/copying-objects/fundamentals.md
+++ b/docs/input/docs/copying-objects/fundamentals.md
@@ -4,7 +4,7 @@ Title: Fundamentals
 Description: Introduction to the copy capabilities
 ---
 
-## Distinction towards .NET Framework interfaces
+# Distinction towards .NET Framework interfaces
 
 There is the **[System.ICloneable]** interface which as the documentation states
 

--- a/docs/input/docs/getting-started/configure.md
+++ b/docs/input/docs/getting-started/configure.md
@@ -7,18 +7,18 @@ Description: Configure BBT.StructureTools
 The BBT Structure Tools are entirely configurable by code. This section covers the
 correct IoC container registration of the infrastructure components.
 
-## Preconditions
+# Preconditions
 
 * The library requires an IoC container to resolve components internally.
 
-## IoC Container
+# IoC Container
 
 The library is usable with any IoC container, but it must support some preconditions:
 
 * Injection to public constructors of `internal` classes
 * Registration of unbound generic types
 
-### Initialization
+## Initialization
 
 Before the registrations can be done the `IocHandler` resolver must be set.
 Implement the resolver using the `IIocResolver`.

--- a/docs/input/docs/getting-started/obtain.md
+++ b/docs/input/docs/getting-started/obtain.md
@@ -4,7 +4,7 @@ Title: Obtain
 Description: Obtain BBT.StructureTools
 ---
 
-## NuGet
+# NuGet
 
 Release and Beta versions of BBT.Structure tools are available from [nuget.org](https://www.nuget.org/packages/BBT.StructureTools)
 

--- a/docs/input/docs/getting-started/principles.md
+++ b/docs/input/docs/getting-started/principles.md
@@ -20,7 +20,7 @@ according to the user-made registrations.
 | Conversion    | `IConvert<in TSourceClass, in TTargetClass, TConvertIntention>`| `IBaseConvertIntention` |
 | Copy          | `ICopy<in TClassToCopy>`                                       | no intention            |
 
-## Registration interfaces
+# Registration interfaces
 
 The paragraph above states the technical difference between the operations regarding the business case specific intention.
 This is a rather minor difference - As mentioned before, the base objects do the job or resolving the sub operations
@@ -53,7 +53,7 @@ ___
 * Do not mix registrations for multiple types into one implementation - See [Single Responsibility Principle]
 :::
 
-## Controlling object initialization
+# Controlling object initialization
 
 The copy and convert registrations can create a new instance of a target object if neccessary.
 How an object is initialized is defined by a registration of an `IInstanceCreator`
@@ -71,7 +71,7 @@ registrations so the library can detect it while converting or copying objects.
 default generic `InstanceCreator` because the default constructor is used there.
 :::
 
-## Processings and Interceptions
+# Processings and Interceptions
 
 Copy, Convert, and Compare can be controlled depending on the objects being processed by using
 post-, preprocessings, or interceptors.
@@ -82,7 +82,7 @@ as additional argument.
 If possible, use the generic implementations supplied with the libary.
 :::
 
-### Preprocessings
+## Preprocessings
 
 Preprocessings are executed before the object is processed.
 
@@ -92,7 +92,7 @@ Preprocessings are executed before the object is processed.
 | Conversion    | `IConvertPreProcessing<TSoureClass, TTargetClass>`            |
 | Copy          | not supported                                                 |
 
-### Postprocessings
+## Postprocessings
 
 Postprocessings are executed after the object is processed.
 
@@ -102,7 +102,7 @@ Postprocessings are executed after the object is processed.
 | Conversion    | `IConvertPostProcessing<TSoureClass, TTargetClass>`           |
 | Copy          | `ICopyPostProcessing<TClassToCopy>`                           |
 
-### Interceptors
+## Interceptors
 
 Interceptors analyze a given object and stop the copy or convert process from continuing
 if a specified condition is met.

--- a/docs/input/docs/getting-started/whystructuretools.md
+++ b/docs/input/docs/getting-started/whystructuretools.md
@@ -4,7 +4,7 @@ Title: Why does BBT.StructureTools exist?
 Description: Introduction to BBT.StructureTools, what problems are solved and how it is distinctive from the known .NET functions
 ---
 
-## Solve business problems
+# Solve business problems
 
 BBT.StructureTools is a toolset intended to help you handle a tree-like business object structure in relation to the
 following tasks:


### PR DESCRIPTION
Wyam requires headings to start with H1 that headings appear in the TOC on the right sidebar.