### PR TITLE
OperationConditionalCreateToManyWithReverseRelation convert operation fixed

### DIFF
--- a/src/BBT.StructureTools.Tests/Convert/TestData/TargetBaseLeaf.cs
+++ b/src/BBT.StructureTools.Tests/Convert/TestData/TargetBaseLeaf.cs
@@ -10,9 +10,26 @@ namespace BBT.StructureTools.Tests.Convert.TestData
     /// </summary>
     public class TargetBaseLeaf
     {
+        private TargetRoot root;
+
         /// <summary>
-        /// Gets or sets TargetRoot.
+        /// Gets or sets Root.
         /// </summary>
-        public TargetRoot TargetRoot { get; set; }
+        public TargetRoot TargetRoot
+        {
+            get
+            {
+                return this.root;
+            }
+
+            set
+            {
+                this.root = value;
+                if (value != null)
+                {
+                    value.TargetLeafs.Add(this);
+                }
+            }
+        }
     }
 }

--- a/src/BBT.StructureTools.Tests/Convert/TestData/TargetBaseLeaf.cs
+++ b/src/BBT.StructureTools.Tests/Convert/TestData/TargetBaseLeaf.cs
@@ -21,7 +21,6 @@ namespace BBT.StructureTools.Tests.Convert.TestData
             {
                 return this.root;
             }
-
             set
             {
                 this.root = value;

--- a/src/BBT.StructureTools.Tests/Convert/TestData/TargetTreeLeaf.cs
+++ b/src/BBT.StructureTools.Tests/Convert/TestData/TargetTreeLeaf.cs
@@ -24,7 +24,6 @@
             {
                 return this.targetTree;
             }
-
             set
             {
                 this.targetTree = value;

--- a/src/BBT.StructureTools.Tests/Convert/TestData/TargetTreeLeaf.cs
+++ b/src/BBT.StructureTools.Tests/Convert/TestData/TargetTreeLeaf.cs
@@ -8,6 +8,8 @@
     /// </summary>
     public class TargetTreeLeaf
     {
+        private TargetTree targetTree;
+
         /// <summary>
         /// Gets the Id.
         /// </summary>
@@ -16,7 +18,22 @@
         /// <summary>
         /// Gets or sets TargetTree.
         /// </summary>
-        public TargetTree TargetTree { get; set; }
+        public TargetTree TargetTree
+        {
+            get
+            {
+                return this.targetTree;
+            }
+
+            set
+            {
+                this.targetTree = value;
+                if (value != null)
+                {
+                    value.TargetLeafs.Add(this);
+                }
+            }
+        }
 
         /// <summary>
         /// Gets or sets OriginLeaf.

--- a/src/BBT.StructureTools/Convert/Strategy/OperationConditionalCreateToManyWithReverseRelation.cs
+++ b/src/BBT.StructureTools/Convert/Strategy/OperationConditionalCreateToManyWithReverseRelation.cs
@@ -43,6 +43,7 @@
         public void Execute(TSource source, TTarget target, ICollection<IBaseAdditionalProcessing> additionalProcessings)
         {
             var sourceChildren = this.source.Invoke(source);
+            var childTargets = new List<TBaseTarget>();
             foreach (var sourceChildElement in sourceChildren)
             {
                 var instanceCreationStrategy = this.createInstanceStrategyProvider.GetStrategy(sourceChildElement);
@@ -53,10 +54,12 @@
 
                 // set reverse relation
                 childTarget.SetPropertyValue(this.reverseRelationOnTarget, target);
-
-                // Add to target collection
-                this.targetParentExpression.Compile().Invoke(target).Add(childTarget);
+                childTargets.Add(childTarget);
             }
+
+            target.AddRangeFilterNullValues(
+                this.targetParentExpression,
+                childTargets);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Fixes #89.
OperationConditionalCreateToManyWithReverseRelation convert operation fixed - filter for duplicate entries.
Tests and fest data enhanced (scenarios for handling of composition with list properties added)