### PR TITLE
Fixes issue #134.

### DIFF
--- a/src/BBT.StructureTools.Extensions/Convert/CreateConvertFromStrategy/CreateConvertFromStrategyHelper.cs
+++ b/src/BBT.StructureTools.Extensions/Convert/CreateConvertFromStrategy/CreateConvertFromStrategyHelper.cs
@@ -26,15 +26,18 @@
         }
 
         /// <inheritdoc/>
-        public TTarget CreateTarget(TSource source, ICollection<IBaseAdditionalProcessing> additionalProcessings)
+        public void Convert(TSource source, TTarget target, ICollection<IBaseAdditionalProcessing> additionalProcessings)
         {
-            source.NotNull(nameof(source));
-            additionalProcessings.NotNull(nameof(additionalProcessings));
+            var strategy = this.strategyProvider.GetStrategy(source);
+            strategy.Convert(source, target, additionalProcessings);
+        }
 
+        /// <inheritdoc/>
+        public TTarget Create(TSource source)
+        {
             var strategy = this.strategyProvider.GetStrategy(source);
 
             var concreteTarget = strategy.CreateTarget(source);
-            strategy.Convert(source, concreteTarget, additionalProcessings);
 
             return concreteTarget;
         }

--- a/src/BBT.StructureTools.Extensions/Convert/CreateConvertFromStrategy/CreateConvertFromStrategyHelperReverse.cs
+++ b/src/BBT.StructureTools.Extensions/Convert/CreateConvertFromStrategy/CreateConvertFromStrategyHelperReverse.cs
@@ -30,18 +30,19 @@
         }
 
         /// <inheritdoc/>
-        public TTarget CreateTarget(
-            TSource source,
-            TReverseRelation reverseRelation,
-            ICollection<IBaseAdditionalProcessing> additionalProcessings)
+        public void Convert(TSource source, TTarget target, ICollection<IBaseAdditionalProcessing> additionalProcessings)
         {
-            source.NotNull(nameof(source));
-            reverseRelation.NotNull(nameof(reverseRelation));
+            var strategy = this.strategyProvider.GetStrategy(source);
+            strategy.Convert(source, target, additionalProcessings);
+        }
 
+        /// <inheritdoc/>
+        public TTarget Create(TSource source, TReverseRelation reverseRelation)
+        {
             var strategy = this.strategyProvider.GetStrategy(source);
             var concreteTarget = strategy.CreateTarget(source);
             concreteTarget.SetPropertyValue(this.reverseRelationExpr, reverseRelation);
-            strategy.Convert(source, concreteTarget, additionalProcessings);
+            
             return concreteTarget;
         }
 

--- a/src/BBT.StructureTools.Extensions/Convert/CreateTargetConvertTarget/CreateTargetConvertTargetHelper.cs
+++ b/src/BBT.StructureTools.Extensions/Convert/CreateTargetConvertTarget/CreateTargetConvertTargetHelper.cs
@@ -47,19 +47,17 @@
         }
 
         /// <inheritdoc/>
-        public TTarget CreateTarget(
-            TSource source,
-            TReverseRelation reverseRelation,
-            ICollection<IBaseAdditionalProcessing> additionalProcessings)
+        public TTarget Create(TSource source, TReverseRelation reverseRelation)
         {
-            source.NotNull(nameof(source));
-            reverseRelation.NotNull(nameof(reverseRelation));
-            additionalProcessings.NotNull(nameof(additionalProcessings));
-
             var target = this.instanceCreator.Create();
             target.SetPropertyValue(this.reverseRelationExpr, reverseRelation);
-            this.convert.Convert(source, target, additionalProcessings);
             return target;
+        }
+
+        /// <inheritdoc/>
+        public void Convert(TSource source, TTarget target, ICollection<IBaseAdditionalProcessing> additionalProcessings)
+        {
+            this.convert.Convert(source, target, additionalProcessings);
         }
     }
 
@@ -92,15 +90,15 @@
         }
 
         /// <inheritdoc/>
-        public TTarget CreateTarget(
-            TSource source,
-            ICollection<IBaseAdditionalProcessing> additionalProcessings)
+        public void Convert(TSource source, TTarget target, ICollection<IBaseAdditionalProcessing> additionalProcessings)
         {
-            source.NotNull(nameof(source));
-            additionalProcessings.NotNull(nameof(additionalProcessings));
-
-            var target = this.instanceCreator.Create();
             this.convert.Convert(source, target, additionalProcessings);
+        }
+
+        /// <inheritdoc/>
+        public TTarget Create(TSource source)
+        {
+            var target = this.instanceCreator.Create();
             return target;
         }
     }

--- a/src/BBT.StructureTools.Extensions/Convert/CreateTargetImplConvertTarget/CreateTargetImplConvertTargetHelper.cs
+++ b/src/BBT.StructureTools.Extensions/Convert/CreateTargetImplConvertTarget/CreateTargetImplConvertTargetHelper.cs
@@ -47,19 +47,17 @@
         }
 
         /// <inheritdoc/>
-        public TTarget CreateTarget(
-            TSource source,
-            TReverseRelation reverseRelation,
-            ICollection<IBaseAdditionalProcessing> additionalProcessings)
+        public TTarget Create(TSource source, TReverseRelation reverseRelation)
         {
-            source.NotNull(nameof(source));
-            reverseRelation.NotNull(nameof(reverseRelation));
-            additionalProcessings.NotNull(nameof(additionalProcessings));
-
             var target = this.instanceCreator.Create();
             target.SetPropertyValue(this.reverseRelationExpr, reverseRelation);
-            this.convert.Convert(source, target, additionalProcessings);
             return target;
+        }
+
+        /// <inheritdoc/>
+        public void Convert(TSource source, TTarget target, ICollection<IBaseAdditionalProcessing> additionalProcessings)
+        {
+            this.convert.Convert(source, target, additionalProcessings);
         }
     }
 
@@ -93,15 +91,15 @@
         }
 
         /// <inheritdoc/>
-        public TTarget CreateTarget(
-            TSource source,
-            ICollection<IBaseAdditionalProcessing> additionalProcessings)
+        public void Convert(TSource source, TTarget target, ICollection<IBaseAdditionalProcessing> additionalProcessings)
         {
-            source.NotNull(nameof(source));
-            additionalProcessings.NotNull(nameof(additionalProcessings));
-
-            var target = this.instanceCreator.Create();
             this.convert.Convert(source, target, additionalProcessings);
+        }
+
+        /// <inheritdoc/>
+        public TTarget Create(TSource source)
+        {
+            var target = this.instanceCreator.Create();
             return target;
         }
     }

--- a/src/BBT.StructureTools.Extensions/Convert/CreateTargetImplConvertTargetImpl/CreateTargetImplConvertTargetImplHelper.cs
+++ b/src/BBT.StructureTools.Extensions/Convert/CreateTargetImplConvertTargetImpl/CreateTargetImplConvertTargetImplHelper.cs
@@ -32,15 +32,15 @@
         }
 
         /// <inheritdoc/>
-        public TTarget CreateTarget(
-            TSource source,
-            ICollection<IBaseAdditionalProcessing> additionalProcessings)
+        public void Convert(TSource source, TTarget target, ICollection<IBaseAdditionalProcessing> additionalProcessings)
         {
-            source.NotNull(nameof(source));
-            additionalProcessings.NotNull(nameof(additionalProcessings));
+            this.convert.Convert(source, (TTargetImpl)target, additionalProcessings);
+        }
 
+        /// <inheritdoc/>
+        public TTarget Create(TSource source)
+        {
             var target = this.instanceCreator.Create();
-            this.convert.Convert(source, target, additionalProcessings);
 
             return target;
         }

--- a/src/BBT.StructureTools.Extensions/Convert/CreateTargetImplConvertTargetImpl/CreateTargetImplConvertTargetImplHelperReverse.cs
+++ b/src/BBT.StructureTools.Extensions/Convert/CreateTargetImplConvertTargetImpl/CreateTargetImplConvertTargetImplHelperReverse.cs
@@ -44,20 +44,19 @@
         }
 
         /// <inheritdoc/>
-        public TTarget CreateTarget(
-            TSource source,
-            TReverseRelation reverseRelation,
-            ICollection<IBaseAdditionalProcessing> additionalProcessings)
+        public TTarget Create(TSource source, TReverseRelation reverseRelation)
         {
-            source.NotNull(nameof(source));
-            reverseRelation.NotNull(nameof(reverseRelation));
-            additionalProcessings.NotNull(nameof(additionalProcessings));
-
             var target = this.instanceCreator.Create();
             target.SetPropertyValue(this.reverseRelationExpr, reverseRelation);
-            this.convert.Convert(source, target, additionalProcessings);
 
             return target;
+        }
+
+        /// <inheritdoc/>
+        public void Convert(
+            TSource source, TTarget target, ICollection<IBaseAdditionalProcessing> additionalProcessings)
+        {
+            this.convert.Convert(source, (TTargetImpl)target, additionalProcessings);
         }
     }
 }

--- a/src/BBT.StructureTools.Tests/Convert/CreateConvertFromStrategy/CreateConvertFromStrategyHelperTests.cs
+++ b/src/BBT.StructureTools.Tests/Convert/CreateConvertFromStrategy/CreateConvertFromStrategyHelperTests.cs
@@ -34,7 +34,8 @@
 
             var processings = new List<IBaseAdditionalProcessing>();
             var source = new SourceDerivedLeaf();
-            var target = testCandidate.CreateTarget(source, processings);
+            var target = testCandidate.Create(source);
+            testCandidate.Convert(source, target, processings);
 
             target.Should().NotBeNull();
             target.Should().BeOfType<TargetDerivedLeaf>();
@@ -55,7 +56,8 @@
             var processings = new List<IBaseAdditionalProcessing>();
             var source = new SourceDerivedLeaf();
             var reverseRelation = new TargetRoot();
-            var target = testCandidate.CreateTarget(source, reverseRelation, processings);
+            var target = testCandidate.Create(source, reverseRelation);
+            testCandidate.Convert(source, target, processings);
 
             target.Should().NotBeNull();
             target.Should().BeOfType<TargetDerivedLeaf>();

--- a/src/BBT.StructureTools.Tests/Convert/CreateTargetConvertTarget/CreateTargetConvertTargetHelperTests.cs
+++ b/src/BBT.StructureTools.Tests/Convert/CreateTargetConvertTarget/CreateTargetConvertTargetHelperTests.cs
@@ -30,7 +30,8 @@
 
             var processings = new List<IBaseAdditionalProcessing>();
             var source = new SourceTreeLeaf();
-            var target = testCandidate.CreateTarget(source, processings);
+            var target = testCandidate.Create(source);
+            testCandidate.Convert(source, target, processings);
 
             target.Should().NotBeNull();
             target.OriginId.Should().Be(source.Id);
@@ -48,7 +49,8 @@
             var processings = new List<IBaseAdditionalProcessing>();
             var source = new SourceTreeLeaf();
             var reverseRelation = new TargetTree();
-            var target = testCandidate.CreateTarget(source, reverseRelation, processings);
+            var target = testCandidate.Create(source, reverseRelation);
+            testCandidate.Convert(source, target, processings);
 
             target.Should().NotBeNull();
             target.OriginId.Should().Be(source.Id);

--- a/src/BBT.StructureTools.Tests/Convert/CreateTargetImplConvertTarget/CreateTargetImplConvertTargetHelperTests.cs
+++ b/src/BBT.StructureTools.Tests/Convert/CreateTargetImplConvertTarget/CreateTargetImplConvertTargetHelperTests.cs
@@ -30,7 +30,8 @@
 
             var processings = new List<IBaseAdditionalProcessing>();
             var source = new SourceTreeLeaf();
-            var target = testCandidate.CreateTarget(source, processings);
+            var target = testCandidate.Create(source);
+            testCandidate.Convert(source, target, processings);
 
             target.Should().NotBeNull();
             target.OriginId.Should().Be(source.Id);
@@ -48,7 +49,8 @@
             var processings = new List<IBaseAdditionalProcessing>();
             var source = new SourceTreeLeaf();
             var reverseRelation = new TargetTree();
-            var target = testCandidate.CreateTarget(source, reverseRelation, processings);
+            var target = testCandidate.Create(source, reverseRelation);
+            testCandidate.Convert(source, target, processings);
 
             target.Should().NotBeNull();
             target.OriginId.Should().Be(source.Id);

--- a/src/BBT.StructureTools.Tests/Convert/CreateTargetImplConvertTargetImpl/CreateTargetImplConvertTargetImplHelperTests.cs
+++ b/src/BBT.StructureTools.Tests/Convert/CreateTargetImplConvertTargetImpl/CreateTargetImplConvertTargetImplHelperTests.cs
@@ -30,7 +30,8 @@
 
             var processings = new List<IBaseAdditionalProcessing>();
             var source = new SourceTreeLeaf();
-            var target = testCandidate.CreateTarget(source, processings);
+            var target = testCandidate.Create(source);
+            testCandidate.Convert(source, target, processings);
 
             target.Should().NotBeNull();
             target.OriginId.Should().Be(source.Id);
@@ -48,7 +49,8 @@
             var processings = new List<IBaseAdditionalProcessing>();
             var source = new SourceTreeLeaf();
             var reverseRelation = new TargetTree();
-            var target = testCandidate.CreateTarget(source, reverseRelation, processings);
+            var target = testCandidate.Create(source, reverseRelation);
+            testCandidate.Convert(source, target, processings);
 
             target.Should().NotBeNull();
             target.OriginId.Should().Be(source.Id);

--- a/src/BBT.StructureTools/Convert/ICreateConvertHelper.cs
+++ b/src/BBT.StructureTools/Convert/ICreateConvertHelper.cs
@@ -23,11 +23,18 @@
         void SetupReverseRelation(Expression<Func<TTarget, TReverseRelation>> reverseRelationExpr);
 
         /// <summary>
-        /// Creates a new <typeparamref name="TTarget"/> converted from <paramref name="source"/>.
+        /// Creates <typeparamref name="TTarget"/> with <paramref name="reverseRelation"/>.
         /// </summary>
-        TTarget CreateTarget(
+        TTarget Create(
             TSource source,
-            TReverseRelation reverseRelation,
+            TReverseRelation reverseRelation);
+
+        /// <summary>
+        /// Converts <paramref name="source"/> into <paramref name="target"/>.
+        /// </summary>
+        void Convert(
+            TSource source,
+            TTarget target,
             ICollection<IBaseAdditionalProcessing> additionalProcessings);
     }
 
@@ -43,10 +50,16 @@
         where TConvertIntention : IBaseConvertIntention
     {
         /// <summary>
-        /// Creates a new <typeparamref name="TTarget"/> converted from <paramref name="source"/>.
+        /// Creates <typeparamref name="TTarget"/>.
         /// </summary>
-        TTarget CreateTarget(
+        TTarget Create(TSource source);
+
+        /// <summary>
+        /// Converts <paramref name="source"/> into <paramref name="target"/>.
+        /// </summary>
+        void Convert(
             TSource source,
+            TTarget target,
             ICollection<IBaseAdditionalProcessing> additionalProcessings);
     }
 }

--- a/src/BBT.StructureTools/Convert/Strategy/OperationCreateFromSourceWithReverseRelation.cs
+++ b/src/BBT.StructureTools/Convert/Strategy/OperationCreateFromSourceWithReverseRelation.cs
@@ -48,14 +48,16 @@
                 return;
             }
 
-            var targetValue = this.createConvertHelper.CreateTarget(
-                    source,
-                    target,
-                    additionalProcessings);
+            var targetValue = this.createConvertHelper.Create(source, target);
 
             target.SetPropertyValue(
                 this.targetExpression,
                 targetValue);
+
+            this.createConvertHelper.Convert(
+                source,
+                targetValue,
+                additionalProcessings);
         }
     }
 }

--- a/src/BBT.StructureTools/Convert/Strategy/OperationCreateToMany.cs
+++ b/src/BBT.StructureTools/Convert/Strategy/OperationCreateToMany.cs
@@ -68,7 +68,7 @@
 
             var sourceValues = this.sourceFunc.Invoke(source);
 
-            var copies = new List<TTargetValue>();
+            var targetList = target.GetList(this.targetExpression);
 
             foreach (var sourceValue in sourceValues)
             {
@@ -78,15 +78,12 @@
                     continue;
                 }
 
-                var copy = this.createConvertHelper.CreateTarget(
-                    sourceValue,
-                    additionalProcessings);
-                copies.Add(copy);
-            }
+                var copy = this.createConvertHelper.Create(sourceValue);
 
-            target.AddRangeFilterNullValues(
-                this.targetExpression,
-                copies);
+                targetList.AddUnique(copy);
+
+                this.createConvertHelper.Convert(sourceValue, copy, additionalProcessings);
+            }
         }
     }
 }

--- a/src/BBT.StructureTools/Convert/Strategy/OperationCreateToManyWithRelation.cs
+++ b/src/BBT.StructureTools/Convert/Strategy/OperationCreateToManyWithRelation.cs
@@ -74,10 +74,9 @@
 
             var sourceValues = this.sourceFunc.Invoke(source);
 
-            var copies = new List<TTargetValue>();
-
             var relation = this.relationFunc(source, target);
 
+            var targetList = target.GetList(this.targetExpression);
             foreach (var sourceValue in sourceValues)
             {
                 if (!this.convertHelper.ContinueConvertProcess<TSourceValue, TTargetValue>(
@@ -86,16 +85,16 @@
                     continue;
                 }
 
-                var copy = this.createConvertHelper.CreateTarget(
+                var copy = this.createConvertHelper.Create(
                     sourceValue,
-                    relation,
-                    additionalProcessings);
-                copies.Add(copy);
-            }
+                    relation);
+                targetList.AddUnique(copy);
 
-            target.AddRangeFilterNullValues(
-                this.targetExpression,
-                copies);
+                this.createConvertHelper.Convert(
+                    sourceValue,
+                    copy,
+                    additionalProcessings);
+            }
         }
     }
 }

--- a/src/BBT.StructureTools/Convert/Strategy/OperationCreateToManyWithRelationInclTargetArg.cs
+++ b/src/BBT.StructureTools/Convert/Strategy/OperationCreateToManyWithRelationInclTargetArg.cs
@@ -74,10 +74,9 @@
 
             var sourceValues = this.sourceFunc.Invoke(source, target);
 
-            var copies = new List<TTargetValue>();
-
             var relation = this.relationFunc(source, target);
 
+            var targetList = target.GetList(this.targetExpression);
             foreach (var sourceValue in sourceValues)
             {
                 if (!this.convertHelper.ContinueConvertProcess<TSourceValue, TTargetValue>(
@@ -86,16 +85,17 @@
                     continue;
                 }
 
-                var copy = this.createConvertHelper.CreateTarget(
+                var copy = this.createConvertHelper.Create(
                     sourceValue,
-                    relation,
-                    additionalProcessings);
-                copies.Add(copy);
-            }
+                    relation);
 
-            target.AddRangeFilterNullValues(
-                this.targetExpression,
-                copies);
+                targetList.AddUnique(copy);
+
+                this.createConvertHelper.Convert(
+                    sourceValue,
+                    copy,
+                    additionalProcessings);
+            }
         }
     }
 }

--- a/src/BBT.StructureTools/Convert/Strategy/OperationCreateToManyWithReverseRelation.cs
+++ b/src/BBT.StructureTools/Convert/Strategy/OperationCreateToManyWithReverseRelation.cs
@@ -69,8 +69,7 @@
 
             var sourceValues = this.sourceFunc.Invoke(source);
 
-            var copies = new List<TTargetValue>();
-
+            var targetList = target.GetList(this.targetExpression);
             foreach (var sourceValue in sourceValues)
             {
                 if (!this.convertHelper.ContinueConvertProcess<TSourceValue, TTargetValue>(
@@ -79,16 +78,17 @@
                     continue;
                 }
 
-                var copy = this.createConvertHelper.CreateTarget(
+                var copy = this.createConvertHelper.Create(
                     sourceValue,
-                    target,
-                    additionalProcessings);
-                copies.Add(copy);
-            }
+                    target);
 
-            target.AddRangeFilterNullValues(
-                this.targetExpression,
-                copies);
+                targetList.AddUnique(copy);
+                
+                this.createConvertHelper.Convert(
+                    sourceValue,
+                    copy,
+                    additionalProcessings);
+            }
         }
     }
 }

--- a/src/BBT.StructureTools/Convert/Strategy/OperationCreateToOne.cs
+++ b/src/BBT.StructureTools/Convert/Strategy/OperationCreateToOne.cs
@@ -60,13 +60,13 @@
                 return;
             }
 
-            var targetValue = this.createConvertHelper.CreateTarget(
-                    sourceValue,
-                    additionalProcessings);
+            var targetValue = this.createConvertHelper.Create(sourceValue);
 
             target.SetPropertyValue(
                 this.targetExpression,
                 targetValue);
+
+            this.createConvertHelper.Convert(sourceValue, targetValue, additionalProcessings);
         }
     }
 }

--- a/src/BBT.StructureTools/Convert/Strategy/OperationCreateToOneHistWithCondition.cs
+++ b/src/BBT.StructureTools/Convert/Strategy/OperationCreateToOneHistWithCondition.cs
@@ -82,8 +82,7 @@
 
             var sourceValues = this.sourceFunc.Invoke(source, target);
 
-            var copies = new List<TTargetValue>();
-
+            var targetList = target.GetList(this.targetExpression);
             foreach (var sourceValue in sourceValues)
             {
                 if (!this.convertHelper.ContinueConvertProcess<TSourceValue, TTargetValue>(
@@ -98,21 +97,22 @@
                     continue;
                 }
 
-                var copy = this.createConvertHelper.CreateTarget(
+                var copy = this.createConvertHelper.Create(
                     sourceValue,
-                    target,
+                    target);
+
+                targetList.AddUnique(copy);
+
+                this.createConvertHelper.Convert(
+                    sourceValue,
+                    copy,
                     additionalProcessings);
-                copies.Add(copy);
-            }
 
-            if (copyToOne)
-            {
-                this.targetValueTemporalDataHandler.SetEndInfinte(copies[0], TemporalConstants.InfiniteDate);
+                if (copyToOne)
+                {
+                    this.targetValueTemporalDataHandler.SetEndInfinte(copy, TemporalConstants.InfiniteDate);
+                }
             }
-
-            target.AddRangeFilterNullValues(
-                this.targetExpression,
-                copies);
         }
     }
 }

--- a/src/BBT.StructureTools/Convert/Strategy/OperationCreateToOneWithRelation.cs
+++ b/src/BBT.StructureTools/Convert/Strategy/OperationCreateToOneWithRelation.cs
@@ -67,14 +67,18 @@
 
             var relation = this.relationFunc(source, target);
 
-            var targetValue = this.createConvertHelper.CreateTarget(
-                    sourceValue,
-                    relation,
-                    additionalProcessings);
+            var targetValue = this.createConvertHelper.Create(
+                sourceValue,
+                relation);
 
             target.SetPropertyValue(
                 this.targetExpression,
                 targetValue);
+
+            this.createConvertHelper.Convert(
+                sourceValue,
+                targetValue,
+                additionalProcessings);
         }
     }
 }

--- a/src/BBT.StructureTools/Convert/Strategy/OperationCreateToOneWithRelationInclTargetArg.cs
+++ b/src/BBT.StructureTools/Convert/Strategy/OperationCreateToOneWithRelationInclTargetArg.cs
@@ -67,14 +67,18 @@
 
             var relation = this.relationFunc(source, target);
 
-            var targetValue = this.createConvertHelper.CreateTarget(
+            var targetValue = this.createConvertHelper.Create(
                     sourceValue,
-                    relation,
-                    additionalProcessings);
+                    relation);
 
             target.SetPropertyValue(
                 this.targetExpression,
                 targetValue);
+
+            this.createConvertHelper.Convert(
+                    sourceValue,
+                    targetValue,
+                    additionalProcessings);
         }
     }
 }

--- a/src/BBT.StructureTools/Convert/Strategy/OperationCreateToOneWithReverseRelation.cs
+++ b/src/BBT.StructureTools/Convert/Strategy/OperationCreateToOneWithReverseRelation.cs
@@ -60,14 +60,18 @@
                 return;
             }
 
-            var targetValue = this.createConvertHelper.CreateTarget(
-                    sourceValue,
-                    target,
-                    additionalProcessings);
+            var targetValue = this.createConvertHelper.Create(
+                sourceValue,
+                target);
 
             target.SetPropertyValue(
                 this.targetExpression,
                 targetValue);
+
+            this.createConvertHelper.Convert(
+                sourceValue,
+                targetValue,
+                additionalProcessings);
         }
     }
 }

--- a/src/BBT.StructureTools/Convert/Strategy/OperationMergeLevel.cs
+++ b/src/BBT.StructureTools/Convert/Strategy/OperationMergeLevel.cs
@@ -77,8 +77,6 @@
 
             var mergeValues = this.mergeFunc.Invoke(source);
 
-            var copies = new List<TTargetValue>();
-
             foreach (var mergeValue in mergeValues)
             {
                 if (!this.convertHelper.ContinueConvertProcess<TMergeValue, TTargetValue>(
@@ -89,6 +87,7 @@
 
                 var sourceValues = this.sourceFunc.Invoke(mergeValue);
 
+                var targetList = target.GetList(this.targetExpression);
                 foreach (var sourceValue in sourceValues)
                 {
                     if (!this.convertHelper.ContinueConvertProcess<TSourceValue, TTargetValue>(
@@ -97,17 +96,18 @@
                         continue;
                     }
 
-                    var copy = this.createConvertHelper.CreateTarget(
+                    var copy = this.createConvertHelper.Create(
                         sourceValue,
-                        target,
+                        target);
+
+                    targetList.AddUnique(copy);
+
+                    this.createConvertHelper.Convert(
+                        sourceValue,
+                        copy,
                         additionalProcessings);
-                    copies.Add(copy);
                 }
             }
-
-            target.AddRangeFilterNullValues(
-                this.targetExpression,
-                copies);
         }
     }
 }

--- a/src/BBT.StructureTools/Extension/ReferenceTypeExtension.cs
+++ b/src/BBT.StructureTools/Extension/ReferenceTypeExtension.cs
@@ -12,6 +12,45 @@
     internal static class ReferenceTypeExtension
     {
         /// <summary>
+        /// Adds <paramref name="value"/> to <paramref name="targetList"/>.
+        /// But only if <paramref name="value"/> is not already added.
+        /// </summary>
+        /// <typeparam name="TValue">Type of list entries.</typeparam>
+        internal static void AddUnique<TValue>(
+            this ICollection<TValue> targetList,
+            TValue value)
+            where TValue : class
+        {
+            targetList.NotNull(nameof(targetList));
+            value.NotNull(nameof(value));
+
+            if (!targetList.Contains(value))
+            {
+                targetList.Add(value);
+            }
+        }
+
+        /// <summary>
+        /// Gets the list of <paramref name="target"/> collection property
+        /// according to <paramref name="targetExpression"/>.
+        /// </summary>
+        /// <typeparam name="TTarget">The owner of the list.</typeparam>
+        /// <typeparam name="TValue">The type of list entries.</typeparam>
+        internal static ICollection<TValue> GetList<TTarget, TValue>(
+            this TTarget target,
+            Expression<Func<TTarget, ICollection<TValue>>> targetExpression)
+            where TTarget : class
+            where TValue : class
+        {
+            target.NotNull(nameof(target));
+            targetExpression.NotNull(nameof(targetExpression));
+
+            var targetListFunc = targetExpression.Compile();
+            var targetList = targetListFunc.Invoke(target);
+            return targetList;
+        }
+
+        /// <summary>
         /// An extension enabling addition of many elements to an enumeration without adding null values within the origin.
         /// </summary>
         /// <typeparam name="TTarget">The type of the owner of the collection property.</typeparam>


### PR DESCRIPTION
CreateConvertHelper method CreateTarget split into Create and Convert methods. Operations adapted, created instances are added to list properties before convert is called.