### PR TITLE
Fix LINQ error in `EqualityComparerHelperStrategyUtils`

### DIFF
--- a/src/BBT.StructureTools/Compare/Helper/Strategy/EqualityComparerHelperStrategyUtils.cs
+++ b/src/BBT.StructureTools/Compare/Helper/Strategy/EqualityComparerHelperStrategyUtils.cs
@@ -122,7 +122,7 @@
             return comparer
                 .GetType()
                 .GetMethods()
-                .First(x => x.Name == nameof(comparer.GetHashCode))
+                .First(x => x.Name == nameof(comparer.GetHashCode) && x.GetParameters().Length > 0)
                 .GetParameters()
                 .First()
                 .ParameterType;


### PR DESCRIPTION
Fixes a LINQ error that returned the `GetHashCode` method without any parameters, but in the very next statements the parameters of the first method found would be required.